### PR TITLE
[WIP] Support SAML2 authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gem 'archivesspace-client'
 gem 'mechanize'
 gem 'rake'
 gem 'thor'
+gem 'selenium-webdriver'
+gem 'webdrivers', '~> 5.0'
 
 group :development do
   gem "capistrano", "~> 3.16"

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,14 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'archivesspace-client'
+gem 'mechanize'
 gem 'rake'
+gem 'thor'
 
 group :development do
   gem "capistrano", "~> 3.16"
   gem "capistrano-bundler"
+  gem "pry-byebug"
 end
 
 group :test, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       sshkit (>= 1.9.0)
     capistrano-bundler (2.0.1)
       capistrano (~> 3.1)
+    childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
@@ -101,6 +102,11 @@ GEM
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     rubyntlm (0.6.3)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.1.0)
+      childprocess (>= 0.5, < 5.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2)
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -109,6 +115,10 @@ GEM
       unf_ext
     unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    webdrivers (5.0.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webrick (1.7.0)
     webrobots (0.1.2)
 
@@ -124,7 +134,9 @@ DEPENDENCIES
   rake
   rspec
   rubocop
+  selenium-webdriver
   thor
+  webdrivers (~> 5.0)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
     archivesspace-client (0.1.11)
@@ -9,6 +11,7 @@ GEM
       json (~> 2.0)
       nokogiri (~> 1.10)
     ast (2.4.2)
+    byebug (11.1.3)
     capistrano (3.16.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -16,20 +19,41 @@ GEM
       sshkit (>= 1.9.0)
     capistrano-bundler (2.0.1)
       capistrano (~> 3.1)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dry-cli (0.7.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
     httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     json (2.6.1)
+    mechanize (2.8.4)
+      addressable (~> 2.8)
+      domain_name (~> 0.5, >= 0.5.20190701)
+      http-cookie (~> 1.0, >= 1.0.3)
+      mime-types (~> 3.0)
+      net-http-digest_auth (~> 1.4, >= 1.4.1)
+      net-http-persistent (>= 2.5.2, < 5.0.dev)
+      nokogiri (~> 1.11, >= 1.11.2)
+      rubyntlm (~> 0.6, >= 0.6.3)
+      webrick (~> 1.7)
+      webrobots (~> 0.1.2)
+    method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_portile2 (2.7.1)
     multi_xml (0.6.0)
+    net-http-digest_auth (1.4.1)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
@@ -39,6 +63,13 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    public_suffix (4.0.6)
     racc (1.6.0)
     rainbow (3.1.1)
     rake (13.0.6)
@@ -69,10 +100,17 @@ GEM
     rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
+    rubyntlm (0.6.3)
     sshkit (1.21.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    thor (1.2.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
+    webrick (1.7.0)
+    webrobots (0.1.2)
 
 PLATFORMS
   ruby
@@ -81,9 +119,12 @@ DEPENDENCIES
   archivesspace-client
   capistrano (~> 3.16)
   capistrano-bundler
+  mechanize
+  pry-byebug
   rake
   rspec
   rubocop
+  thor
 
 BUNDLED WITH
    2.1.4

--- a/PRINCETON_VPN.md
+++ b/PRINCETON_VPN.md
@@ -1,0 +1,11 @@
+# Ruby for ArchivesSpace
+
+## Connecting to the Princeton University Network
+
+### Using GlobalProtect
+
+Please download the system package from the [Office of Information Technology](https://princeton.service-now.com/service?id=kb_article&sys_id=125a7bb11b6b4850435885d56b4bcb05#section4)
+
+Following this, please open the Google Cloud Shell environment, and select the `Upload Files...` menu item.
+
+

--- a/cli.thor
+++ b/cli.thor
@@ -3,6 +3,8 @@ require 'mechanize'
 require "open3"
 require 'pry-byebug'
 require "thor"
+require 'selenium-webdriver'
+require 'webdrivers'
 
 module Saml2
   class Idp
@@ -14,14 +16,17 @@ module Saml2
   end
 
   class Agent
-    def initialize(idp:, username:, password:)
+    def initialize(idp:, username:, password:, cli:)
       @idp = idp
       @username = username
       @password = password
+      @cli = cli
     end
 
     def execute!
-      stdout, status = Open3.capture2("/usr/bin/env openconnect --protocol=gp --user=#{@username} --passwd-on-stdin vpn.princeton.edu", stdin_data: @secret)
+      #stdout, status = Open3.capture2("/usr/bin/env openconnect --protocol=gp --user=#{@username} --passwd-on-stdin --verbose vpn.princeton.edu", stdin_data: @secret)
+      @cli.say("Please invoke the following:")
+      @cli.say("echo '#{@secret}' | /usr/bin/env openconnect --protocol=gp --user=#{@username} --passwd-on-stdin --verbose vpn.princeton.edu")
     end
 
     def authenticate!
@@ -36,32 +41,137 @@ module Saml2
       }
       @idp.uri.query = URI.encode_www_form(params)
 
+      # chromedriver
+      options = Selenium::WebDriver::Chrome::Options.new(args: ['headless'])
+      driver = Selenium::WebDriver.for(:chrome, options: options)
+
+      driver.get(@idp.uri)
+
+      #auth_form = page.form_with(action: 'login')
+      #auth_form.username = @username
+      #auth_form.password = @password
+
+      auth_form = driver.find_element(tag_name: 'form', action: 'login')
+
+      username_input = auth_form.find_element(name: 'username')
+      username_input.send_keys(@username)
+
+      password_input = auth_form.find_element(name: 'password')
+      password_input.send_keys(@password)
+
+      submit_button = auth_form.find_elements(tag_name: 'button', type: 'submit', value: 'Login').last
+      submit_button.click
+
+      # Find the DUO button
+      mfa_frames = driver.find_elements(tag_name: "iframe")
+
+      driver.switch_to.frame(mfa_frames.first)
+
+      mfa_buttons = driver.find_elements(class: "auth-button")
+
+      driver.save_screenshot("debug0.png")
+      mfa_buttons.first.click
+      sleep(0.5)
+      driver.save_screenshot("debug1.png")
+
+      cancel_button = driver.find_element(class: "btn-cancel")
+      driver.save_screenshot("debug1b.png")
+
+      @cli.say("Two-factor authorization request pushed to Duo...")
+      while driver.current_url == 'localhost'
+        sleep(0.2)
+      end
+
+      driver.switch_to.default_content
+
+      content_div = driver.find_element(class: 'content')
+      content_text = content_div.attribute("textContent").strip
+      if content_text.include?("Sorry, it looks like there is a problem finding your session.")
+        raise(StandardError, "Authorization Error: #{content_text}")
+      end
+
+      # End the session
+      driver.quit
+    end
+
+    def mechanize!
+      agent = Mechanize.new do |a|
+        a.redirect_ok = true
+      end
+
+      @idp.uri = URI.parse("https://fed.princeton.edu/cas/login")
+      params = {
+        service: 'https://idp.princeton.edu/idp/Authn/External?conversation=e1s1',
+        entityId: 'https://vpn.princeton.edu:443/SAML20/SP'
+      }
+      @idp.uri.query = URI.encode_www_form(params)
+
       # Retrieve the IdP authentication page
       agent.get(@idp.uri) do |page|
-
-        # Submit the IdP authentication form
         saml_cookies = agent.cookies.select { |cookie| cookie.domain == 'fed.princeton.edu' }
-        if !saml_cookies.empty?
+
+        # Submit the IdP authentication form if there is no authentication
+        if saml_cookies.empty?
+          auth_form = page.form_with(action: 'login')
+          auth_form.username = @username
+          auth_form.password = @password
+          mfa_page = auth_form.submit
+          saml_cookies = agent.cookies.select { |cookie| cookie.domain == 'fed.princeton.edu' }
+
+          if mfa_page.body.include?('duo_iframe')
+            # Submit the multi-factor authentication form
+
+            # Mechanize requires <iframe> interaction first
+            #agent.click(mfa_page.iframes.first)
+            duo_page = mfa_page.iframes.first.content
+            duo_form = duo_page.forms.first
+            duo_form.username = @username
+            duo_form.password = @password
+            execution = duo_form.execution
+            #duo_response = duo_form.submit
+            #duo_response = agent.submit(duo_form, duo_form.buttons.first)
+
+            uri = URI.parse("https://fed.princeton.edu/cas/login")
+            params = {
+              service: 'https://idp.princeton.edu/idp/Authn/External?conversation=e1s1',
+              entityId: 'https://vpn.princeton.edu:443/SAML20/SP'
+            }
+            uri.query = URI.encode_www_form(params)
+            duo_response = agent.post(uri, {
+              username: @username,
+              password: @password,
+              execution: execution,
+              _eventId: 'submit',
+              geolocation: nil
+            })
+
+            # This is manual
+            duo_uri = URI.parse("https://api-dc8397fa.duosecurity.com/frame/web/v1/auth")
+            duo_params = {
+              service: 'https://idp.princeton.edu/idp/Authn/External?conversation=e1s1',
+              entityId: 'https://vpn.princeton.edu:443/SAML20/SP',
+              tx: 'TX|anJnNXxESUpXRTA1NUdFNERHMUdVMU5IU3wxNjQ1NTUzNzI4|b845a02fe3c4697414246a31695b75477e188737',
+              parent: duo_response.uri,
+              v: '2.6'
+            }
+            duo_uri.query = URI.encode_www_form(duo_params)
+            duo_response2 = agent.get(duo_uri)
+
+            @secret = agent.cookies.first.value
+
+            # https://idp.princeton.edu/idp/Authn/External?conversation=e1s1&ticket=ST-68462-L-1zl-dwUBs5FQKeDjtrIVAHVH4-fed
+            # Wait for https://idp.princeton.edu/idp/profile/SAML2/POST/SSO?execution=e1s1&_eventId_proceed=1
+            # Then POST SAMLResponse
+            execute!
+          else
+            raise(NotImplementedError, "Unhandled server response: #{mfa_page.uri}")
+          end
+        else
           if saml_cookies.length == 1
             @secret = saml_cookies.first.value
           else
             raise(NotImplementedError, "Multiple SAML digests stored as cookies: #{saml_cookies}")
           end
-        elsif page.body.include?('duo_iframe')
-          # Submit the multi-factor authentication form
-
-          # Mechanize requires <iframe> interaction first
-          agent.click(page.iframes.first)
-          duo_page = page.iframes.first.content
-          duo_form = duo_page.forms.first
-          duo_form.username = @username
-          duo_form.password = @password
-          results_page = duo_form.submit
-          @secret = agent.cookies.first.value
-
-          binding.pry
-        else
-          raise(NotImplementedError, "Unhandled server response: #{page.uri}")
         end
 
         # Invoke the `openconnect binary with the SAML digest here
@@ -80,9 +190,10 @@ class Aspace < Thor
 
     username = ask("Please enter your NetID:")
     password = ask("Please enter your password:", echo: false)
+    say("Authenticating...")
 
     idp = Saml2::Idp.new(protocol: protocol, host: host, path: path)
-    agent = Saml2::Agent.new(idp: idp, username: username, password: password)
+    agent = Saml2::Agent.new(idp: idp, username: username, password: password, cli: self)
     agent.authenticate!
   end
 end

--- a/cli.thor
+++ b/cli.thor
@@ -1,0 +1,67 @@
+require "httparty"
+require 'mechanize'
+require 'pry-byebug'
+require "thor"
+
+module Saml2
+  class Idp
+    attr_accessor :uri
+
+    def initialize(protocol:, host:, path:)
+      @uri = URI.parse("#{protocol}://#{host}#{path}")
+    end
+  end
+
+  class Agent
+    def initialize(idp:, username:, password:)
+      @idp = idp
+      @username = username
+      @password = password
+    end
+
+    def authenticate!
+      agent = Mechanize.new do |a|
+        a.redirect_ok = true
+      end
+
+      @idp.uri = URI.parse("https://fed.princeton.edu/cas/login")
+      params = {
+        service: 'https://idp.princeton.edu/idp/Authn/External?conversation=e1s1',
+        entityId: 'https://vpn.princeton.edu:443/SAML20/SP'
+      }
+      @idp.uri.query = URI.encode_www_form(params)
+
+      # Retrieve the IdP authentication page
+      agent.get(@idp.uri) do |page|
+
+        # Submit the IdP authentication form
+        auth_form = page.form_with(action: 'login')
+        auth_form.username = @username
+        auth_form.password = @password
+        mfa_page = auth_form.submit
+
+        # Submit the multi-factor authentication form
+        mfa_form = mfa_page.form_with(action: '/cas/login')
+        mfa_response = mfa_form.submit
+
+        # Invoke the `openconnect binary with the SAML digest here
+      end
+    end
+  end
+end
+
+class Aspace < Thor
+  desc "auth", "Authenticate"
+  def auth
+    protocol = "https"
+    host = "idp.princeton.edu"
+    path = "/idp/profile/SAML2/Redirect/SSO"
+
+    username = ask("Please enter your NetID:")
+    password = ask("Please enter your password:", echo: false)
+
+    idp = Saml2::Idp.new(protocol: protocol, host: host, path: path)
+    agent = Saml2::Agent.new(idp: idp, username: username, password: password)
+    agent.authenticate!
+  end
+end


### PR DESCRIPTION
This advances #12 by introducing experimental support for network authentication using `thor` and `selenium-webdriver` for interaction using a web browser (there lies also attempts using the `mechanize` Gem). In order to address higher priority issues, this may need to be delayed before the first workshop session (this feature is not essential for the first workshop).